### PR TITLE
fixed issues w/ deleting columns that didn't exist

### DIFF
--- a/gtk-version/cmds.c
+++ b/gtk-version/cmds.c
@@ -2710,9 +2710,9 @@ void do_name(arg)
 void do_r_col(col)
      int col;
 {
-  if (col > max_col)
+  if (col > max_col ||    (strncmp(head.ch[col].name,"no_val",6) == 0) )
     {
-      coe();
+      coe();		//in messages.c
     }
   else
     {


### PR DESCRIPTION
Addresses #2 by not allowing cols that don't exist to be removed.  We were removing cols that didn't exist in prev. version and then n_cols (header) was incorrect.